### PR TITLE
Update esp_idf_depency. Confirmed working on 0.34.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["embedded", "api-bindings"]
 default = ["log"]
 
 [dependencies]
-esp-idf-sys = { version = "0.33.0" }
+esp-idf-sys = { version = "0" }
 # If the `log` feature is enabled, the crate does some internal logging during the OTA operations
 log = { version = "0.4", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["embedded", "api-bindings"]
 default = ["log"]
 
 [dependencies]
-esp-idf-sys = { version = "0" }
+esp-idf-sys = { version = "0.34.0" }
 # If the `log` feature is enabled, the crate does some internal logging during the OTA operations
 log = { version = "0.4", optional = true }
 


### PR DESCRIPTION
The version restriction of 0.33.0 is a bit outdated, but the API has not changed.