### PR TITLE
Upgrade  from 0.34 to 0.35 to build in current esp-rs/esp-idf-template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 /.embuild
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ add, fix, increase, force etc.. Not added, fixed, increased, forced etc.
 
 ## [Unreleased]
 
+## [0.2.1] - 2024-12-29
+### Changed
+- Upgrade `esp-idf-sys` from 0.34 to 0.35 to build in current esp-rs/esp-idf-template.
 
 ## [0.2.0] - 2023-07-09
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-ota"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Linus Färnstrand <faern@faern.net>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/faern/esp-ota"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["embedded", "api-bindings"]
 default = ["log"]
 
 [dependencies]
-esp-idf-sys = { version = "0.34.0" }
+esp-idf-sys = { version = "0.35.0" }
 # If the `log` feature is enabled, the crate does some internal logging during the OTA operations
 log = { version = "0.4", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,17 @@ ota_0,    app,  ota_0,   0x10000, 0x180000,
 ota_1,    app,  ota_1,   0x190000, 0x180000,
 ```
 
-And tell espflash to use it in `Cargo.toml`. Read more in the [cargo espflash documentation]:
+And tell espflash to use it in `.cargo/config.toml` similar to the following according to your target. Read more in the [cargo espflash documentation](https://github.com/esp-rs/espflash/blob/main/cargo-espflash/README.md#bootloader-and-partition-table).
 ```toml
-[package.metadata.espflash]
-partition_table = "partitions.csv"
+[build]
+target = "xtensa-esp32s3-espidf"
+
+[target.xtensa-esp32s3-espidf]
+linker = "ldproxy"
+runner = "espflash flash --monitor --partition-table=partitions.csv"
 ```
+
+
 
 [cargo espflash documentation]: https://github.com/esp-rs/espflash/blob/master/cargo-espflash/README.md#package-metadata
 [ESP partition tables]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html


### PR DESCRIPTION
Just a quick fix for this when using esp-idf-svc 0.49 (the latest, which re-exports esp-idf-sys 0.35). Thanks for the work!

```
error: failed to select a version for `esp-idf-sys`.
... required by package `esp-ota v0.2.0`
... which satisfies dependency `esp-ota = "^0.2.0"` of package `esp-ota-std-ex v0.1.0 (/home/gp/Dropbox/dev/rust/esp-ota/esp-ota-std-ex)`
versions that meet the requirements `^0.33.0` are: 0.33.7, 0.33.6, 0.33.5, 0.33.4, 0.33.3, 0.33.2, 0.33.1, 0.33.0

the package `esp-idf-sys` links to the native library `esp_idf`, but it conflicts with a previous package which links to `esp_idf` as well:
package `esp-idf-sys v0.35.0`
... which satisfies dependency `esp-idf-sys = "^0.35"` of package `esp-idf-hal v0.44.1`
... which satisfies dependency `esp-idf-hal = "^0.44"` of package `esp-idf-svc v0.49.0`
... which satisfies dependency `esp-idf-svc = "^0.49"` of package `esp-ota-std-ex v0.1.0 (/home/gp/Dropbox/dev/rust/esp-ota/esp-ota-std-ex)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the `links = "esp_idf"` value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `esp-idf-sys` which could resolve this conflict
```